### PR TITLE
Support multiple config files in command args

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,13 +33,17 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn get(filename: &str) -> Result<Configuration, String> {
-        let toml_content = match fs::read_to_string(filename) {
-            Ok(v) => v,
-            Err(err) => return Err(format!("read config file error: {}", err).to_string()),
-        };
+    pub fn get(filenames: Vec<String>) -> Result<Configuration, String> {
+        let mut content: String = String::new();
 
-        let config: Configuration = match toml::from_str(&toml_content) {
+        for file_name in &filenames {
+            content.push_str(&match fs::read_to_string(file_name) {
+                Ok(v) => v,
+                Err(err) => return Err(format!("read config file error: {}", err).to_string()),
+            });
+        }
+
+        let config: Configuration = match toml::from_str(&content) {
             Ok(v) => v,
             Err(err) => return Err(format!("parse config file error: {}", err)),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,15 @@ fn main() {
                 .short("c")
                 .long("config")
                 .value_name("FILE")
+                .multiple(true)
+                .number_of_values(1)
                 .help("Path to configuration file")
                 .takes_value(true),
         )
         .get_matches();
 
-    let config_file = matches.value_of_lossy("config").unwrap();
-    let config = config::Configuration::get(&config_file).expect("read configuration error");
+    let config_files = matches.values_of_lossy("config").unwrap_or(vec![]);
+    let config = config::Configuration::get(config_files).expect("read configuration error");
     let log_level =
         log::Level::from_str(&config.udp_bridge.log_level).expect("parse log_level error");
 


### PR DESCRIPTION
This allows to start the UDP Bridge with multiple --config arguments (or -c) to provide multiple configuration files.
The files are concatenated and then parsed as before.
The set of files must be consistent (e.g. each toml section only once between the files)

The concentratord has a similar behavior.