### PR TITLE
Remove the "stat" entry in the PUSH_DATA packet when the object is null

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -176,6 +176,7 @@ impl PushData {
 #[derive(Serialize)]
 pub struct PushDataPayload {
     pub rxpk: Vec<RXPK>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stat: Option<Stat>,
 }
 


### PR DESCRIPTION
The [Semtech UDP protocol states](https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT#L197) : 

> The root object can also contain an object named "stat" :
> 
> ``` json
> {
> 	"rxpk":[ {...}, ...],
> 	"stat":{...}
> }
> ```

Actually, when the stat object is null, the UDP forwarder adds a null "stat" entry:

``` json
{
	"rxpk":[ {...}, ...],
	"stat": null
}
```

Even if the protocol specification is not clear and this is correct regarding JSON, some LNS do not support a null stat object. Not having the stat entry at all in that case would improve interoperability.

This patch is done on v3 (025b886fcc7bfc23aa6b0c5ee3f39e75909a10d6) but there is no such branch on the repo.

