### PR TITLE
Remove the "tmms" entry in the txpk object when the entry is null

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -185,9 +185,9 @@ pub struct RXPK {
     #[serde(with = "compact_time_format")]
     pub time: DateTime<Utc>,
     /// GPS time of pkt RX, number of milliseconds since 06.Jan.1980
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tmms: Option<u64>,
     /// Internal timestamp of "RX finished" event (32b unsigned)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tmst: u32,
     /// RX central frequency in MHz (unsigned float, Hz precision)
     pub freq: f64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -187,6 +187,7 @@ pub struct RXPK {
     /// GPS time of pkt RX, number of milliseconds since 06.Jan.1980
     pub tmms: Option<u64>,
     /// Internal timestamp of "RX finished" event (32b unsigned)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tmst: u32,
     /// RX central frequency in MHz (unsigned float, Hz precision)
     pub freq: f64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -839,7 +839,7 @@ mod tests {
 
         assert_eq!(
             str::from_utf8(&b[12..]).unwrap(),
-            r#"{"rxpk":[{"time":"1970-01-01T00:00:00+00:00","tmms":1000,"tmst":16909060,"freq":868.3,"chan":1,"rfch":2,"stat":1,"modu":"FSK","datr":50000,"codr":null,"rssi":-160,"lsnr":null,"size":3,"data":"AQID"}],"stat":null}"#
+            r#"{"rxpk":[{"time":"1970-01-01T00:00:00+00:00","tmms":1000,"tmst":16909060,"freq":868.3,"chan":1,"rfch":2,"stat":1,"modu":"FSK","datr":50000,"rssi":-160,"size":3,"data":"AQID"}],"stat":null}"#
         );
     }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -202,10 +202,12 @@ pub struct RXPK {
     /// LoRa datarate identifier (eg. SF12BW500)}
     pub datr: DataRate,
     /// LoRa coding rate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub codr: Option<CodeRate>,
     /// RSSI in dBm (signed integer, 1 dB precision).
     pub rssi: i32,
     /// Lora SNR ratio in dB (signed float, 0.1 dB precision).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lsnr: Option<f32>,
     /// RF packet payload size in bytes (unsigned integer).
     pub size: u8,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -176,6 +176,7 @@ impl PushData {
 #[derive(Serialize)]
 pub struct PushDataPayload {
     pub rxpk: Vec<RXPK>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stat: Option<Stat>,
 }
 


### PR DESCRIPTION
The [Semtech UDP protocol states](https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT#L134) : 

> The root object can contain an array named "rxpk":
> 
> ``` json
> {
> 	"rxpk":[ {...}, ...]
> }
> ```
> 
> That array contains at least one JSON object, each object contain a RF packet 
> and associated metadata with the following fields:
> 
>  Name |  Type  | Function
> :----:|:------:|--------------------------------------------------------------
>  time | string | UTC time of pkt RX, us precision, ISO 8601 'compact' format
>  tmms | number | GPS time of pkt RX, number of milliseconds since 06.Jan.1980
>  tmst | number | Internal timestamp of "RX finished" event (32b unsigned)
>  freq | number | RX central frequency in MHz (unsigned float, Hz precision)
>  chan | number | Concentrator "IF" channel used for RX (unsigned integer)
>  rfch | number | Concentrator "RF chain" used for RX (unsigned integer)
>  stat | number | CRC status: 1 = OK, -1 = fail, 0 = no CRC
>  modu | string | Modulation identifier "LORA" or "FSK"
>  datr | string | LoRa datarate identifier (eg. SF12BW500)
>  datr | number | FSK datarate (unsigned, in bits per second)
>  codr | string | LoRa ECC coding rate identifier
>  rssi | number | RSSI in dBm (signed integer, 1 dB precision)
>  lsnr | number | Lora SNR ratio in dB (signed float, 0.1 dB precision)
>  size | number | RF packet payload size in bytes (unsigned integer)
>  data | string | Base64 encoded RF packet payload, padded

- So tmms should be mandatory. 
- However, the examples shown are all missing the tmms field.
- There is no example of a null field, but it should be valid in JSON.

So most correct would certainly be setting to null, as it's done now. But as it's not clear, to maximize interoperability, I suggest not setting the tmms field if value is null. In v1.3 of the protocol, this field did not exist. So retro-compatibility of implementations will guarantee it works.

What do you think is best?